### PR TITLE
fix:修复取消倒计时在对话框消失后依然回调的问题

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -27,18 +27,9 @@
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value>
-          <package name="java.util" alias="false" withSubpackages="false" />
-          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
-          <package name="io.ktor" alias="false" withSubpackages="true" />
-        </value>
-      </option>
-      <option name="PACKAGES_IMPORT_LAYOUT">
-        <value>
-          <package name="" alias="false" withSubpackages="true" />
-          <package name="java" alias="false" withSubpackages="true" />
-          <package name="javax" alias="false" withSubpackages="true" />
-          <package name="kotlin" alias="false" withSubpackages="true" />
-          <package name="" alias="true" withSubpackages="true" />
+          <package name="java.util" withSubpackages="false" static="false" />
+          <package name="kotlinx.android.synthetic" withSubpackages="true" static="false" />
+          <package name="io.ktor" withSubpackages="true" static="false" />
         </value>
       </option>
     </JetCodeStyleSettings>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,7 +5,7 @@
       <configuration PROFILE_NAME="Debug" CONFIG_NAME="Debug" />
     </configurations>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="12" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/miui-dialogs/src/main/java/com/peanut/sdk/miuidialog/MIUIDialog.kt
+++ b/miui-dialogs/src/main/java/com/peanut/sdk/miuidialog/MIUIDialog.kt
@@ -172,6 +172,7 @@ class MIUIDialog(private val context: Context, private val miuiVersion: Int = MI
      * Cancel the dialog.
      */
     fun cancel() = dialog?.cancel()
+    fun isShowing() = dialog?.isShowing
 
     /**
      * Gets the input EditText for the dialog.
@@ -291,20 +292,23 @@ class MIUIDialog(private val context: Context, private val miuiVersion: Int = MI
                             var i = -1
                             while (second-++i>0){
                                 Handler(context.mainLooper).post {
+                                    this@MIUIDialog.setActionButtonEnabled(WhichButton.NEGATIVE,false)
                                     it.text = String.format("%s(%d)",userText,second-i)
                                 }
                                 sleep(1000)
                             }
                             Handler(context.mainLooper).post {
                                 it.text = userText
-                                it.performClick()
+                                this@MIUIDialog.setActionButtonEnabled(WhichButton.NEGATIVE,true)
                             }
                         }
                     }.start()
                 }
                 it.setOnClickListener {
-                    wrapper.click?.invoke(this)
-                    cancel()
+                    if(isShowing() == true){
+                        wrapper.click?.invoke(this)
+                        cancel()
+                    }
                 }
                 view.findViewById<LinearLayout>(R.id.miui_action_panel).visible()
             }


### PR DESCRIPTION
2020.9.13 
修复取消倒计时在对话框消失后依然回调的问题
修复了取消倒计时按钮在倒计时期间依然可以点击的问题